### PR TITLE
Add new regions (sa-brazil-1, sa-chile-1, sa-argentina-1, sa-peru-1 and na-mexico-1) on services

### DIFF
--- a/huaweicloud-sdk-antiddos/huaweicloudsdkantiddos/v1/region/antiddos_region.py
+++ b/huaweicloud-sdk-antiddos/huaweicloudsdkantiddos/v1/region/antiddos_region.py
@@ -36,6 +36,16 @@ class AntiDDoSRegion:
 
     RU_NORTHWEST_2 = Region(id="ru-northwest-2", endpoint="https://antiddos.ru-northwest-2.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://antiddos.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://antiddos.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://antiddos.na-mexico-1.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://antiddos.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://antiddos.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "cn-north-1": CN_NORTH_1,
         "cn-north-2": CN_NORTH_2,
@@ -50,6 +60,11 @@ class AntiDDoSRegion:
         "ap-southeast-3": AP_SOUTHEAST_3,
         "af-south-1": AF_SOUTH_1,
         "ru-northwest-2": RU_NORTHWEST_2,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-as/huaweicloudsdkas/v1/region/as_region.py
+++ b/huaweicloud-sdk-as/huaweicloudsdkas/v1/region/as_region.py
@@ -34,6 +34,18 @@ class AsRegion:
 
     RU_NORTHWEST_2 = Region(id="ru-northwest-2", endpoint="https://as.ru-northwest-2.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://as.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://as.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://as.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://as.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://as.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://as.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -47,6 +59,12 @@ class AsRegion:
         "ap-southeast-3": AP_SOUTHEAST_3,
         "cn-north-2": CN_NORTH_2,
         "ru-northwest-2": RU_NORTHWEST_2,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-bcs/huaweicloudsdkbcs/v2/region/bcs_region.py
+++ b/huaweicloud-sdk-bcs/huaweicloudsdkbcs/v2/region/bcs_region.py
@@ -24,6 +24,8 @@ class BcsRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://bcs.ap-southeast-3.myhuaweicloud.com")
 
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://bcs.la-south-2.myhuaweicloud.com")
+
     static_fields = {
         "cn-north-1": CN_NORTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -32,6 +34,7 @@ class BcsRegion:
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'la-south-2': LA_SOUTH_2,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-bms/huaweicloudsdkbms/v1/region/bms_region.py
+++ b/huaweicloud-sdk-bms/huaweicloudsdkbms/v1/region/bms_region.py
@@ -30,6 +30,16 @@ class BmsRegion:
 
     RU_NORTHWEST_2 = Region(id="ru-northwest-2", endpoint="https://bms.ru-northwest-2.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://bms.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://bms.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://bms.na-mexico-1.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://bms.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://bms.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "cn-north-2": CN_NORTH_2,
         "cn-north-4": CN_NORTH_4,
@@ -41,6 +51,11 @@ class BmsRegion:
         "ap-southeast-3": AP_SOUTHEAST_3,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ru-northwest-2": RU_NORTHWEST_2,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-cbr/huaweicloudsdkcbr/v1/region/cbr_region.py
+++ b/huaweicloud-sdk-cbr/huaweicloudsdkcbr/v1/region/cbr_region.py
@@ -32,6 +32,8 @@ class CbrRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://cbr.ap-southeast-3.myhuaweicloud.com")
 
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://cbr.la-south-2.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -44,6 +46,7 @@ class CbrRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'la-south-2': LA_SOUTH_2,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-cce/huaweicloudsdkcce/v3/region/cce_region.py
+++ b/huaweicloud-sdk-cce/huaweicloudsdkcce/v3/region/cce_region.py
@@ -32,6 +32,18 @@ class CceRegion:
 
     AF_SOUTH_1 = Region(id="af-south-1", endpoint="https://cce.af-south-1.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://cce.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://cce.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://cce.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://cce.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://cce.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://cce.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "cn-north-1": CN_NORTH_1,
         "cn-north-2": CN_NORTH_2,
@@ -44,6 +56,12 @@ class CceRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-3": AP_SOUTHEAST_3,
         "af-south-1": AF_SOUTH_1,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-ces/huaweicloudsdkces/v1/region/ces_region.py
+++ b/huaweicloud-sdk-ces/huaweicloudsdkces/v1/region/ces_region.py
@@ -30,6 +30,18 @@ class CesRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://ces.ap-southeast-3.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://ces.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://ces.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://ces.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://ces.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://ces.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://ces.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -41,6 +53,12 @@ class CesRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-ces/huaweicloudsdkces/v2/region/ces_region.py
+++ b/huaweicloud-sdk-ces/huaweicloudsdkces/v2/region/ces_region.py
@@ -30,6 +30,18 @@ class CesRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://ces.ap-southeast-3.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://ces.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://ces.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://ces.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://ces.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://ces.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://ces.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -41,6 +53,12 @@ class CesRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-cts/huaweicloudsdkcts/v3/region/cts_region.py
+++ b/huaweicloud-sdk-cts/huaweicloudsdkcts/v3/region/cts_region.py
@@ -30,6 +30,8 @@ class CtsRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://cts.ap-southeast-3.myhuaweicloud.com")
 
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://cts.la-south-2.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -41,6 +43,7 @@ class CtsRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'la-south-2': LA_SOUTH_2,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-dds/huaweicloudsdkdds/v3/region/dds_region.py
+++ b/huaweicloud-sdk-dds/huaweicloudsdkdds/v3/region/dds_region.py
@@ -36,6 +36,18 @@ class DdsRegion:
 
     CN_NORTH_2 = Region(id="cn-north-2", endpoint="https://dds.cn-north-2.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://dds.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://dds.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://dds.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://dds.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://dds.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://dds.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -50,6 +62,12 @@ class DdsRegion:
         "ru-northwest-2": RU_NORTHWEST_2,
         "cn-south-2": CN_SOUTH_2,
         "cn-north-2": CN_NORTH_2,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-dms/huaweicloudsdkdms/v2/region/dms_region.py
+++ b/huaweicloud-sdk-dms/huaweicloudsdkdms/v2/region/dms_region.py
@@ -38,6 +38,8 @@ class DmsRegion:
 
     CN_NORTH_9 = Region(id="cn-north-9", endpoint="https://dms.cn-north-9.myhuaweicloud.com")
 
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://dms.la-south-2.myhuaweicloud.com")
+
     static_fields = {
         "cn-north-1": CN_NORTH_1,
         "cn-north-2": CN_NORTH_2,
@@ -53,6 +55,7 @@ class DmsRegion:
         "af-south-1": AF_SOUTH_1,
         "ru-northwest-2": RU_NORTHWEST_2,
         "cn-north-9": CN_NORTH_9,
+        'la-south-2': LA_SOUTH_2,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-dns/huaweicloudsdkdns/v2/region/dns_region.py
+++ b/huaweicloud-sdk-dns/huaweicloudsdkdns/v2/region/dns_region.py
@@ -30,6 +30,16 @@ class DnsRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://dns.ap-southeast-3.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://dns.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://dns.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://dns.na-mexico-1.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://dns.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://dns.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "cn-east-2": CN_EAST_2,
         "cn-east-3": CN_EAST_3,
@@ -41,6 +51,11 @@ class DnsRegion:
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-ecs/huaweicloudsdkecs/v2/region/ecs_region.py
+++ b/huaweicloud-sdk-ecs/huaweicloudsdkecs/v2/region/ecs_region.py
@@ -30,6 +30,18 @@ class EcsRegion:
 
     AF_SOUTH_1 = Region(id="af-south-1", endpoint="https://ecs.af-south-1.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://ecs.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://ecs.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://ecs.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://ecs.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://ecs.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://ecs.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "cn-north-1": CN_NORTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -41,6 +53,12 @@ class EcsRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-3": AP_SOUTHEAST_3,
         "af-south-1": AF_SOUTH_1,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-elb/huaweicloudsdkelb/v2/region/elb_region.py
+++ b/huaweicloud-sdk-elb/huaweicloudsdkelb/v2/region/elb_region.py
@@ -32,6 +32,18 @@ class ElbRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://elb.ap-southeast-3.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://elb.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://elb.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://elb.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://elb.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://elb.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://elb.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -44,6 +56,12 @@ class ElbRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-elb/huaweicloudsdkelb/v3/region/elb_region.py
+++ b/huaweicloud-sdk-elb/huaweicloudsdkelb/v3/region/elb_region.py
@@ -32,6 +32,18 @@ class ElbRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://elb.ap-southeast-3.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://elb.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://elb.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://elb.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://elb.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://elb.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://elb.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -44,6 +56,12 @@ class ElbRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-evs/huaweicloudsdkevs/v2/region/evs_region.py
+++ b/huaweicloud-sdk-evs/huaweicloudsdkevs/v2/region/evs_region.py
@@ -32,6 +32,18 @@ class EvsRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://evs.ap-southeast-3.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://evs.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://evs.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://evs.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://evs.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://evs.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://evs.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -44,6 +56,12 @@ class EvsRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-functiongraph/huaweicloudsdkfunctiongraph/v2/region/functiongraph_region.py
+++ b/huaweicloud-sdk-functiongraph/huaweicloudsdkfunctiongraph/v2/region/functiongraph_region.py
@@ -30,6 +30,12 @@ class FunctionGraphRegion:
 
     CN_SOUTHWEST_2 = Region(id="cn-southwest-2", endpoint="https://functiongraph.cn-southwest-2.myhuaweicloud.com")
 
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://functiongraph.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://functiongraph.la-south-2.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://functiongraph.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "cn-north-4": CN_NORTH_4,
         "cn-north-1": CN_NORTH_1,
@@ -41,6 +47,9 @@ class FunctionGraphRegion:
         "ap-southeast-3": AP_SOUTHEAST_3,
         "af-south-1": AF_SOUTH_1,
         "cn-southwest-2": CN_SOUTHWEST_2,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-ims/huaweicloudsdkims/v2/region/ims_region.py
+++ b/huaweicloud-sdk-ims/huaweicloudsdkims/v2/region/ims_region.py
@@ -34,6 +34,18 @@ class ImsRegion:
 
     CN_SOUTH_2 = Region(id="cn-south-2", endpoint="https://ims.cn-south-2.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://ims.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://ims.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://ims.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://ims.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://ims.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://ims.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -47,6 +59,12 @@ class ImsRegion:
         "ap-southeast-3": AP_SOUTHEAST_3,
         "cn-north-2": CN_NORTH_2,
         "cn-south-2": CN_SOUTH_2,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-kms/huaweicloudsdkkms/v1/region/kms_region.py
+++ b/huaweicloud-sdk-kms/huaweicloudsdkkms/v1/region/kms_region.py
@@ -32,6 +32,14 @@ class KmsRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://kms.ap-southeast-3.myhuaweicloud.com")
 
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://kms.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://kms.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://kms.la-south-2.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://kms.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "cn-north-4": CN_NORTH_4,
         "cn-north-1": CN_NORTH_1,
@@ -44,6 +52,10 @@ class KmsRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-kms/huaweicloudsdkkms/v2/region/kms_region.py
+++ b/huaweicloud-sdk-kms/huaweicloudsdkkms/v2/region/kms_region.py
@@ -32,6 +32,14 @@ class KmsRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://kms.ap-southeast-3.myhuaweicloud.com")
 
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://kms.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://kms.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://kms.la-south-2.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://kms.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "cn-north-4": CN_NORTH_4,
         "cn-north-1": CN_NORTH_1,
@@ -44,6 +52,10 @@ class KmsRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-nat/huaweicloudsdknat/v2/region/nat_region.py
+++ b/huaweicloud-sdk-nat/huaweicloudsdknat/v2/region/nat_region.py
@@ -36,6 +36,18 @@ class NatRegion:
 
     RU_NORTHWEST_2 = Region(id="ru-northwest-2", endpoint="https://nat.ru-northwest-2.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://nat.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://nat.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://nat.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://nat.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://nat.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://nat.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -50,6 +62,12 @@ class NatRegion:
         "cn-south-2": CN_SOUTH_2,
         "cn-north-2": CN_NORTH_2,
         "ru-northwest-2": RU_NORTHWEST_2,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-rds/huaweicloudsdkrds/v3/region/rds_region.py
+++ b/huaweicloud-sdk-rds/huaweicloudsdkrds/v3/region/rds_region.py
@@ -32,6 +32,18 @@ class RdsRegion:
 
     RU_NORTHWEST_2 = Region(id="ru-northwest-2", endpoint="https://rds.ru-northwest-2.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://rds.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://rds.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://rds.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://rds.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://rds.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://rds.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -44,6 +56,12 @@ class RdsRegion:
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
         "ru-northwest-2": RU_NORTHWEST_2,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-sdrs/huaweicloudsdksdrs/v1/region/sdrs_region.py
+++ b/huaweicloud-sdk-sdrs/huaweicloudsdksdrs/v1/region/sdrs_region.py
@@ -24,6 +24,10 @@ class SdrsRegion:
 
     AF_SOUTH_1 = Region(id="af-south-1", endpoint="https://sdrs.af-south-1.myhuaweicloud.com")
 
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://sdrs.la-south-2.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://sdrs.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "ap-southeast-3": AP_SOUTHEAST_3,
         "cn-north-4": CN_NORTH_4,
@@ -32,6 +36,8 @@ class SdrsRegion:
         "cn-east-2": CN_EAST_2,
         "cn-east-3": CN_EAST_3,
         "af-south-1": AF_SOUTH_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-servicestage/huaweicloudsdkservicestage/v2/region/servicestage_region.py
+++ b/huaweicloud-sdk-servicestage/huaweicloudsdkservicestage/v2/region/servicestage_region.py
@@ -30,6 +30,8 @@ class ServiceStageRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://servicestage.ap-southeast-3.myhuaweicloud.com")
 
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://servicestage.la-south-2.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -41,6 +43,7 @@ class ServiceStageRegion:
         "ap-southeast-2": AP_SOUTHEAST_2,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'la-south-2': LA_SOUTH_2,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-smn/huaweicloudsdksmn/v2/region/smn_region.py
+++ b/huaweicloud-sdk-smn/huaweicloudsdksmn/v2/region/smn_region.py
@@ -34,6 +34,18 @@ class SmnRegion:
 
     CN_SOUTH_2 = Region(id="cn-south-2", endpoint="https://smn.cn-south-2.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://smn.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://smn.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://smn.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://smn.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://smn.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://smn.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -47,6 +59,12 @@ class SmnRegion:
         "ap-southeast-3": AP_SOUTHEAST_3,
         "cn-north-2": CN_NORTH_2,
         "cn-south-2": CN_SOUTH_2,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-vpc/huaweicloudsdkvpc/v2/region/vpc_region.py
+++ b/huaweicloud-sdk-vpc/huaweicloudsdkvpc/v2/region/vpc_region.py
@@ -32,6 +32,18 @@ class VpcRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://vpc.ap-southeast-3.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://vpc.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://vpc.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://vpc.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://vpc.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://vpc.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://vpc.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -44,6 +56,12 @@ class VpcRegion:
         "cn-north-9": CN_NORTH_9,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-vpc/huaweicloudsdkvpc/v3/region/vpc_region.py
+++ b/huaweicloud-sdk-vpc/huaweicloudsdkvpc/v3/region/vpc_region.py
@@ -32,6 +32,18 @@ class VpcRegion:
 
     AP_SOUTHEAST_3 = Region(id="ap-southeast-3", endpoint="https://vpc.ap-southeast-3.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://vpc.sa-argentina-1.myhuaweicloud.com")
+
+    SA_PERU_1 = Region(id="sa-peru-1", endpoint="https://vpc.sa-peru-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://vpc.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://vpc.la-south-2.myhuaweicloud.com")
+
+    SA_CHILE_1 = Region(id="sa-chile-1", endpoint="https://vpc.sa-chile-1.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://vpc.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "af-south-1": AF_SOUTH_1,
         "cn-north-4": CN_NORTH_4,
@@ -44,6 +56,12 @@ class VpcRegion:
         "cn-north-9": CN_NORTH_9,
         "ap-southeast-1": AP_SOUTHEAST_1,
         "ap-southeast-3": AP_SOUTHEAST_3,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'sa-peru-1': SA_PERU_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-chile-1': SA_CHILE_1,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod

--- a/huaweicloud-sdk-vpcep/huaweicloudsdkvpcep/v1/region/vpcep_region.py
+++ b/huaweicloud-sdk-vpcep/huaweicloudsdkvpcep/v1/region/vpcep_region.py
@@ -22,6 +22,14 @@ class VpcepRegion:
 
     CN_SOUTHWEST_2 = Region(id="cn-southwest-2", endpoint="https://vpcep.cn-southwest-2.myhuaweicloud.com")
 
+    SA_ARGENTINA_1 = Region(id="sa-argentina-1", endpoint="https://vpcep.sa-argentina-1.myhuaweicloud.com")
+
+    NA_MEXICO_1 = Region(id="na-mexico-1", endpoint="https://vpcep.na-mexico-1.myhuaweicloud.com")
+
+    LA_SOUTH_2 = Region(id="la-south-2", endpoint="https://vpcep.la-south-2.myhuaweicloud.com")
+
+    SA_BRAZIL_1 = Region(id="sa-brazil-1", endpoint="https://vpcep.sa-brazil-1.myhuaweicloud.com")
+
     static_fields = {
         "cn-north-4": CN_NORTH_4,
         "cn-north-1": CN_NORTH_1,
@@ -29,6 +37,10 @@ class VpcepRegion:
         "cn-east-3": CN_EAST_3,
         "cn-south-1": CN_SOUTH_1,
         "cn-southwest-2": CN_SOUTHWEST_2,
+        'sa-argentina-1': SA_ARGENTINA_1,
+        'na-mexico-1': NA_MEXICO_1,
+        'la-south-2': LA_SOUTH_2,
+        'sa-brazil-1': SA_BRAZIL_1,
     }
 
     @staticmethod


### PR DESCRIPTION
Adding new region urls collected from website: https://developer.huaweicloud.com/intl/en-us/endpoint to instantiate services clients by region without manage the endpoint url.