### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,4 +1,6 @@
 name: Publish Python Packages To Pypi
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/huaweicloud/huaweicloud-sdk-python-v3/security/code-scanning/3](https://github.com/huaweicloud/huaweicloud-sdk-python-v3/security/code-scanning/3)

To fix the problem, we should add a `permissions` block to the workflow to explicitly limit the permissions granted to the `GITHUB_TOKEN`. The minimal required permission for publishing to PyPI is typically `contents: read`, as the workflow does not need to write to the repository or access other resources. This block can be added at the root level of the workflow file (above `jobs:`) to apply to all jobs, or at the job level if different jobs require different permissions. In this case, adding it at the root level is sufficient and recommended for clarity. No additional imports or definitions are needed; just a YAML block specifying the permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
