### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-pypi-publish.yml
+++ b/.github/workflows/test-pypi-publish.yml
@@ -1,4 +1,6 @@
 name: Publish Python Packages To Test Pypi
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/huaweicloud/huaweicloud-sdk-python-v3/security/code-scanning/2](https://github.com/huaweicloud/huaweicloud-sdk-python-v3/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or the specific job. The minimal required permission for this workflow is `contents: read`, which allows the workflow to check out the repository code. Since the workflow does not interact with issues, pull requests, or other resources, no additional permissions are needed. The best place to add this is at the top level of the workflow (after the `name:` line), so it applies to all jobs unless overridden. No changes to the steps or logic are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
