### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest-ci.yml
+++ b/.github/workflows/pytest-ci.yml
@@ -1,4 +1,6 @@
 name: Pytest CI
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/huaweicloud/huaweicloud-sdk-python-v3/security/code-scanning/1](https://github.com/huaweicloud/huaweicloud-sdk-python-v3/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. For a typical CI workflow that only checks out code and runs tests, `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). The best way is to add the following block at the top level of the workflow, just after the `name` field and before `on`, to ensure all jobs inherit these minimal permissions. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
